### PR TITLE
Feature/feedme allow reminders

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "jquery": "^2.2.3",
     "jsdom": "^8.4.0",
     "moment": "^2.13.0",
-    "upper-case-first": "^1.1.2",
     "urllib-sync": "^1.1.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "jquery": "^2.2.3",
     "jsdom": "^8.4.0",
     "moment": "^2.13.0",
+    "upper-case-first": "^1.1.2",
     "urllib-sync": "^1.1.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "author": "Lorenz Leutgeb <lorenz.leutgeb@catalysts.cc>",
   "description": "A simple helpful robot for Catalysts",

--- a/scripts/feedme.coffee
+++ b/scripts/feedme.coffee
@@ -16,7 +16,7 @@ FOOD_TIME =
   HOUR : 11
   MINUTE : 45
 
-FOOD_REGEX = "fab?r?i?k?|ern?i?s?|spa?r?|bil?l?a?|bur?g?e?r?k?i?n?g?|bk|gum?p?e?n?d?o?r?f?e?r?|piz?z?a?"
+FOOD_REGEX = "fab?r?i?k?|ern?i?s?|spa?r?|bil?l?a?|bur?g?e?r?k?i?n?g?|bk|gum?p?e?n?d?o?r?f?e?r?|mar?g?a?r?e?t?e?n?g?ü?r?t?e?l?|piz?z?a?"
 
 FOODTYPES =
   fa : "Fabrik"
@@ -25,6 +25,7 @@ FOODTYPES =
   bi : "Billa"
   bu : "Burger King"
   gu : "Gumpendorfer"
+  ma : "Margaretengürtel"
   pi : "Pizza"
 
 fetch = (target) ->
@@ -167,7 +168,7 @@ module.exports = (robot) ->
       \nFabrik: \n#{fabrikMenu}\n
       \nErni's: \n#{ernisMenu}\n
       \nNatürlich gibt es auch noch:
-      \nSpar, Billa, Burgerking, Gumpendorfer oder Pizza."
+      \nSpar, Billa, Burgerking, Gumpendorfer, Margaretengürtel oder Pizza."
 
   # subscribe to food and reminder
   robot.hear (new RegExp("(#{FOOD_REGEX}) \\+(\\d*)", "i"))

--- a/scripts/feedme.coffee
+++ b/scripts/feedme.coffee
@@ -56,17 +56,17 @@ class Fabrik
     $ = require("jquery")(jsdom.jsdom(rawbody).defaultView)
     parsedDates = @parseDates($)
 
+    # fabrik is closed
+    if day > 5
+      @robot.brain.set "feedme.fabrik.save", @errors.closed
+
     # check for outdated menu
-    if now.isAfter(moment(parsedDates[2], "DD.MM.YYYY"), 'day')
+    else if now.isAfter(moment(parsedDates[2], "DD.MM.YYYY"), 'day')
       @robot.brain.set "feedme.fabrik.save", @errors.menuFromPast
 
     # check for future menu
     else if now.isBefore(moment(parsedDates[1], "DD.MM.YYYY"), 'day')
       @robot.brain.set "feedme.fabrik.save", @errors.menuFromFuture
-
-    # fabrik is closed
-    else if day > 5
-      @robot.brain.set "feedme.fabrik.save", @errors.closed
 
     else
       @robot.brain.set "feedme.fabrik.save", @extractMeal($, day)


### PR DESCRIPTION
- you can "subscribe" to a foodtype (Fabrik, Erni's, Spar, Billa, Burgerking, Gumpendorfer or Pizza) by `foodtype +{integer}`, e.g. `ernis +1`. Note: Only your name will be added to the subscriber list as hubot can't possibly know which person is meant by `ernis +2`.
- on default food-time (11:45) all subscribed users will be notified in `#vie-food` (and automagically unsubscribed as they're expected to be fed) 
- you can set the reminder-time with `foodtype time`, e.g. `ernis 12:00`. The old reminder will be cleared and a new will be set. 
- version bump to 0.2.0

fixes:
- change output from fabrik to show correct weekend behaviour
- move date calc to `feedme` command. 
