### PR TITLE
Add gitlab-hooks to catbot

### DIFF
--- a/external-scripts.json
+++ b/external-scripts.json
@@ -8,5 +8,6 @@
   "hubot-maps",
   "hubot-redis-brain",
   "hubot-rules",
-  "hubot-shipit"
+  "hubot-shipit",
+  "hubot-gitlab-hooks"
 ]

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "hubot": "^2.18.0",
     "hubot-diagnostics": "0.0.1",
+    "hubot-gitlab-hooks": "^0.5.0",
     "hubot-google-images": "^0.2.6",
     "hubot-google-translate": "^0.2.0",
     "hubot-help": "^0.1.3",


### PR DESCRIPTION
Which channel should receive messages can be configured via the Hook URL, so we don't need to set those parameters. For the the rest, look [here.](https://www.npmjs.com/package/hubot-gitlab-hooks)
